### PR TITLE
no-jira - Remove correlationID from frames options

### DIFF
--- a/Risk.podspec
+++ b/Risk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "Risk"
-    s.version      = "3.0.0"
+    s.version      = "3.0.1"
     s.summary      = "Checkout Risk package in Swift"
     s.description  = <<-DESC
     Checkout Risk package in Swift.

--- a/Sources/Risk/Logging/Constants.swift
+++ b/Sources/Risk/Logging/Constants.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum Constants {
     static let productName = "risk-ios-sdk"
-    static let riskSdkVersion = "3.0.0"
+    static let riskSdkVersion = "3.0.1"
     static let userAgent = "checkout-sdk-risk-ios/\(riskSdkVersion)"
     static let loggerTypeIdentifier = "com.checkout.risk-mobile-sdk"
 }

--- a/Sources/Risk/Logging/LoggerService.swift
+++ b/Sources/Risk/Logging/LoggerService.swift
@@ -153,9 +153,6 @@ struct LoggerService: LoggerServiceProtocol {
                 environment: internalConfig.environment.rawValue
             )
         )
-        
-        guard let correlationID = internalConfig.framesOptions?.correlationId else { return }
-        logger.add(metadata: CheckoutEventLogger.MetadataKey.correlationID.rawValue, value: correlationID)
     }
 
     func log(riskEvent: RiskEvent, blockTime: Double? = nil, deviceDataPersistTime: Double? = nil, fpLoadTime: Double? = nil, fpPublishTime: Double? = nil, deviceSessionId: String? = nil, requestId: String? = nil, error: RiskLogError? = nil) {

--- a/Sources/Risk/RiskSDKConfig.swift
+++ b/Sources/Risk/RiskSDKConfig.swift
@@ -28,13 +28,11 @@ public struct RiskConfig {
 }
 
 public struct FramesOptions {
-    let correlationId: String
     let version: String
     let productIdentifier: String
 
-    public init(productIdentifier: String, version: String, correlationId: String) {
+    public init(productIdentifier: String, version: String) {
         self.productIdentifier = productIdentifier
         self.version = version
-        self.correlationId = correlationId
     }
 }


### PR DESCRIPTION
## Issue

NA

## Proposed changes

- Remove correlationID from frames options. It was noticed that when correlationID is passed to the cko ios log package, it causes a bug which makes the app to crash.
