### PR TITLE
Update module name to avoid naming conflicts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "Risk",
-            targets: ["Risk"])
+            targets: ["RiskSDK"])
     ],
     dependencies: [
         .package(
@@ -23,7 +23,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "Risk",
+            name: "RiskSDK",
             dependencies: [
                 .product(name: "CheckoutEventLoggerKit",
                          package: "checkout-event-logger-ios-framework"),
@@ -34,7 +34,7 @@ let package = Package(
             path: "Sources"),
         .testTarget(
             name: "RiskTests",
-            dependencies: ["Risk"],
+            dependencies: ["RiskSDK"],
             path: "Tests")
     ],
     swiftLanguageVersions: [.v5]

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The package helps collect device data for merchants with direct integration (sta
 
 See example below:
 ```swift
-import Risk
+import RiskSDK
 
 // Example usage of package
 let yourConfig = RiskConfig(publicKey: "pk_qa_xxx", environment: RiskEnvironment.qa)

--- a/Tests/Mocks/MockAPIService.swift
+++ b/Tests/Mocks/MockAPIService.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@testable import Risk
+@testable import RiskSDK
 
 class MockAPIService: APIServiceProtocol {
     var expectedResult: Result<DeviceDataConfiguration, Error>?

--- a/Tests/Mocks/MockDeviceDataService.swift
+++ b/Tests/Mocks/MockDeviceDataService.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@testable import Risk
+@testable import RiskSDK
 
 class MockDeviceDataService: DeviceDataServiceProtocol {
     var shouldReturnConfiguration: Bool = true

--- a/Tests/Mocks/MockFingerprintService.swift
+++ b/Tests/Mocks/MockFingerprintService.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@testable import Risk
+@testable import RiskSDK
 
 class MockFingerprintService: FingerprintServiceProtocol {
     var fpLoadTime: Double = 0.0

--- a/Tests/Mocks/MockLoggerService.swift
+++ b/Tests/Mocks/MockLoggerService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import CheckoutEventLoggerKit
-@testable import Risk
+@testable import RiskSDK
 
 struct MockLoggerService: LoggerServiceProtocol {
     private var loggedEvents: [RiskEvent] = []

--- a/Tests/RiskTests/ApiServiceTests.swift
+++ b/Tests/RiskTests/ApiServiceTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-@testable import Risk
+@testable import RiskSDK
 
 class APIServiceTests: XCTestCase {
     

--- a/Tests/RiskTests/DeviceDataServiceTests.swift
+++ b/Tests/RiskTests/DeviceDataServiceTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-@testable import Risk
+@testable import RiskSDK
 
 class DeviceDataServiceTests: XCTestCase {
     func testGetConfiguration() {

--- a/Tests/RiskTests/RiskTests.swift
+++ b/Tests/RiskTests/RiskTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Risk
+@testable import RiskSDK
 
 class RiskTests: XCTestCase {
 


### PR DESCRIPTION
## Proposed changes

When we created an `xcframework` that has the Risk SDK as a dependency, we started to get naming conflict errors since the name of the public class `Risk` and the name of the module were the same `Risk`. This error blocked us to create an xcframework that dynamically depends on the Risk SDK.

In this PR, we change the name of the module, which results in changing the name of the import.

## Checklist

* [x] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes