### PR TITLE
Fixing the callback issues in Risk SDK

### DIFF
--- a/Sources/Risk/Risk.swift
+++ b/Sources/Risk/Risk.swift
@@ -61,8 +61,7 @@ public final class Risk {
           }
         }
 
-        fingerprintService.publishData { [weak self] fpResult in
-          guard let self = self else { return }
+        fingerprintService.publishData { fpResult in
 
           DispatchQueue.main.async {
             guard let timer = self.timer, timer.isValid else { // 2.59 -> valid
@@ -86,11 +85,14 @@ public final class Risk {
     
     private func persistFpData(cardToken: String?, fingerprintRequestId: String, fpLoadTime: Double, fpPublishTime: Double, completion: @escaping (Result<PublishRiskData, RiskError.Publish>) -> Void) {
         self.deviceDataService.persistFpData(fingerprintRequestId: fingerprintRequestId, fpLoadTime: fpLoadTime, fpPublishTime: fpPublishTime, cardToken: cardToken) { result in
-            switch result {
-            case .success(let response):
-                completion(.success(PublishRiskData(deviceSessionId: response.deviceSessionId)))
-            case .failure(let error):
-                completion(.failure(error))
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let response):
+                    print(completion)
+                    completion(.success(PublishRiskData(deviceSessionId: response.deviceSessionId)))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
             }
         }
     }

--- a/Sources/Risk/Risk.swift
+++ b/Sources/Risk/Risk.swift
@@ -88,7 +88,6 @@ public final class Risk {
             DispatchQueue.main.async {
                 switch result {
                 case .success(let response):
-                    print(completion)
                     completion(.success(PublishRiskData(deviceSessionId: response.deviceSessionId)))
                 case .failure(let error):
                     completion(.failure(error))

--- a/Sources/Risk/Services/DeviceDataService.swift
+++ b/Sources/Risk/Services/DeviceDataService.swift
@@ -114,5 +114,4 @@ final class DeviceDataService: DeviceDataServiceProtocol {
             }
         }
     }
-    
 }

--- a/Sources/Risk/Services/FingerprintService.swift
+++ b/Sources/Risk/Services/FingerprintService.swift
@@ -63,23 +63,21 @@ final class FingerprintService: FingerprintServiceProtocol {
         
         let metadata = createMetadata(sourceType: internalConfig.sourceType.rawValue)
         
-        client.getVisitorIdResponse(metadata) { [weak self] result in
-            
-            switch result {
-            case .failure(let error):
-                self?.loggerService.log(riskEvent: .publishFailure, blockTime: self?.blockTime, deviceDataPersistTime: nil, fpLoadTime: self?.fpLoadTime, fpPublishTime: nil, deviceSessionId: nil, requestId: nil, error: RiskLogError(reason: "publishData", message: error.localizedDescription, status: nil, type: "Error"))
-                
-                return completion(.failure(.couldNotPublishRiskData))
-            case let .success(response):
-                let endFpPublishTime = CACurrentMediaTime()
-                self?.fpPublishTime = (endFpPublishTime - startFpPublishTime) * 1000
-                self?.loggerService.log(riskEvent: .collected, blockTime: self?.blockTime, deviceDataPersistTime: nil, fpLoadTime: self?.fpLoadTime, fpPublishTime: self?.fpPublishTime, deviceSessionId: nil, requestId: response.requestId, error: nil)
-                self?.requestId = response.requestId
-                
-                completion(.success(FpPublishData(requestId: response.requestId, fpLoadTime: self?.fpLoadTime ?? 0.00, fpPublishTime: self?.fpPublishTime ?? 0.00)))
+        client.getVisitorIdResponse(metadata) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .failure(let error):
+                    self.loggerService.log(riskEvent: .publishFailure, blockTime: self.blockTime, deviceDataPersistTime: nil, fpLoadTime: self.fpLoadTime, fpPublishTime: nil, deviceSessionId: nil, requestId: nil, error: RiskLogError(reason: "publishData", message: error.localizedDescription, status: nil, type: "Error"))
+                    
+                    return completion(.failure(.couldNotPublishRiskData))
+                case let .success(response):
+                    let endFpPublishTime = CACurrentMediaTime()
+                    self.fpPublishTime = (endFpPublishTime - startFpPublishTime) * 1000
+                    self.loggerService.log(riskEvent: .collected, blockTime: self.blockTime, deviceDataPersistTime: nil, fpLoadTime: self.fpLoadTime, fpPublishTime: self.fpPublishTime, deviceSessionId: nil, requestId: response.requestId, error: nil)
+                    self.requestId = response.requestId
+                    completion(.success(FpPublishData(requestId: response.requestId, fpLoadTime: self.fpLoadTime ?? 0.00, fpPublishTime: self.fpPublishTime ?? 0.00)))
+                }
             }
         }
     }
-    
-    
 }

--- a/Sources/Risk/Services/FingerprintService.swift
+++ b/Sources/Risk/Services/FingerprintService.swift
@@ -63,7 +63,8 @@ final class FingerprintService: FingerprintServiceProtocol {
         
         let metadata = createMetadata(sourceType: internalConfig.sourceType.rawValue)
         
-        client.getVisitorIdResponse(metadata) { result in
+        client.getVisitorIdResponse(metadata) { [weak self] result in
+            guard let self else { return }
             DispatchQueue.main.async {
                 switch result {
                 case .failure(let error):


### PR DESCRIPTION
## Issue

_Issue ticket number and link._

## Proposed changes
Proposed changes remove the usage of [weak self] within the `fingerprintService.publishData ` method. 

## Test Steps

1. Initialize the Risk SDK [as per integration guide on your portal]
2. Use the `riskSDK?.publishData` method after `self.riskSDK?.configure`
3. It should return the device session id, whereas it does not return one.

> For instance testing a timeout feature:
> 1. On the `APIService`, change the `timeoutInterval` to 0.0001.
> 2. Make a network call and assert that the request timed out.
> 3. Revert the value after testing.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [ ] Reviewers assigned
* [x] I have performed a self-review of my code and manual testing
* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered, etc..._



